### PR TITLE
Close yaml files after opening

### DIFF
--- a/openap/drag.py
+++ b/openap/drag.py
@@ -65,7 +65,8 @@ class Drag(object):
                 raise RuntimeError(f"Drag polar for {self.ac} not avaiable in OpenAP.")
 
         f = dir_dragpolar + ac + ".yml"
-        dragpolar = yaml.safe_load(open(f))
+        with open(f, "r") as file:
+            dragpolar = yaml.safe_load(file.read())
         return dragpolar
 
     @ndarrayconvert

--- a/openap/prop.py
+++ b/openap/prop.py
@@ -56,7 +56,8 @@ def aircraft(ac, use_synonym=False, **kwargs):
             raise RuntimeError(f"Aircraft {ac} not avaiable in OpenAP.")
 
     f = files[0]
-    acdict = yaml.safe_load(open(f))
+    with open(f, "r") as file:
+        acdict = yaml.safe_load(file.read())
 
     return acdict
 


### PR DESCRIPTION
Currently, I'm getting the following errors using OpenAP:

```
ResourceWarning: Enable tracemalloc to get the object allocation traceback/Users/User/projects/dissertation/.venv/lib/python3.10/site-packages/openap/prop.py:57: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/User/projects/dissertation/.venv/lib/python3.10/site-packages/openap/data/aircraft/a320.yml' mode='r' encoding='UTF-8'>
  acdict = yaml.safe_load(open(f))
```

This PR is an attempt to fix this error, by wrapping `yaml.safe_load` in a `with` statement, so the file is closed after it's read.